### PR TITLE
Enable swipe-to-delete for events list

### DIFF
--- a/notification_schedule_ios/ViewModels/EventListViewModel.swift
+++ b/notification_schedule_ios/ViewModels/EventListViewModel.swift
@@ -29,4 +29,17 @@ final class EventListViewModel: ObservableObject {
             showError = true
         }
     }
+
+    func delete(at offsets: IndexSet) {
+        let ids = offsets.map { events[$0].id }
+        do {
+            for id in ids {
+                try service.deleteEvent(identifier: id)
+            }
+            events.remove(atOffsets: offsets)
+        } catch {
+            errorMessage = error.localizedDescription
+            showError = true
+        }
+    }
 }

--- a/notification_schedule_ios/Views/EventListView.swift
+++ b/notification_schedule_ios/Views/EventListView.swift
@@ -40,11 +40,16 @@ struct EventListView: View {
             if viewModel.events.isEmpty {
                 EmptyStateView()
             } else {
-                List(viewModel.events) { event in
-                    VStack(alignment: .leading) {
-                        Text(event.title).font(.headline)
-                        Text(event.startDate, style: .date)
-                        Text(event.startDate, style: .time)
+                List {
+                    ForEach(viewModel.events) { event in
+                        VStack(alignment: .leading) {
+                            Text(event.title).font(.headline)
+                            Text(event.startDate, style: .date)
+                            Text(event.startDate, style: .time)
+                        }
+                    }
+                    .onDelete { indexSet in
+                        viewModel.delete(at: indexSet)
                     }
                 }
                 .listStyle(.plain)


### PR DESCRIPTION
## Summary
- allow removing events from the list by swiping and tapping delete
- keep view model in sync by deleting from EventKit and local array

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0341b5c30832ea7c856c47ea10d38