### PR TITLE
Add editing capability to event list

### DIFF
--- a/notification_schedule_ios/Models/AppEvent.swift
+++ b/notification_schedule_ios/Models/AppEvent.swift
@@ -5,11 +5,18 @@ struct AppEvent: Identifiable {
     let title: String
     let startDate: Date
     let notes: String?
+    let minutesBefore: Int
 
     init(event: EKEvent) {
         self.id = event.eventIdentifier
         self.title = event.title
         self.startDate = event.startDate
         self.notes = event.notes
+        if let offset = event.alarms?.first?.relativeOffset {
+            let minutes = Int(round((-offset) / 60))
+            minutesBefore = max(0, minutes)
+        } else {
+            minutesBefore = 0
+        }
     }
 }

--- a/notification_schedule_ios/Services/EventStoreService.swift
+++ b/notification_schedule_ios/Services/EventStoreService.swift
@@ -32,7 +32,9 @@ final class EventStoreService {
     func fetchUpcomingEvents(limit: Int = 30) async throws -> [AppEvent] {
         let calendar = Calendar.current
         let start = calendar.startOfDay(for: Date())
-        guard let end = calendar.date(byAdding: .day, value: 90, to: start) else { return [] }
+        guard let end = calendar.date(byAdding: .day, value: 90, to: start) else {
+            return []
+        }
         let predicate = store.predicateForEvents(withStart: start, end: end, calendars: nil)
         let events = store.events(matching: predicate).sorted { $0.startDate < $1.startDate }
         return events.prefix(limit).map { AppEvent(event: $0) }

--- a/notification_schedule_ios/Views/AddEventView.swift
+++ b/notification_schedule_ios/Views/AddEventView.swift
@@ -2,7 +2,11 @@ import SwiftUI
 
 struct AddEventView: View {
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var viewModel = AddEventViewModel()
+    @StateObject private var viewModel: AddEventViewModel
+
+    init(event: AppEvent? = nil, service: EventStoreService = EventStoreService()) {
+        _viewModel = StateObject(wrappedValue: AddEventViewModel(event: event, service: service))
+    }
 
     var body: some View {
         NavigationStack {
@@ -27,13 +31,13 @@ struct AddEventView: View {
                     Stepper("\(viewModel.minutesBefore)分前", value: $viewModel.minutesBefore, in: 0...1440)
                 }
             }
-            .navigationTitle("予定を追加")
+            .navigationTitle(viewModel.navigationTitle)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("閉じる") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("保存") {
+                    Button(viewModel.confirmButtonTitle) {
                         Task { await viewModel.save() }
                     }
                     .disabled(!viewModel.canSave)

--- a/notification_schedule_ios/Views/EventListView.swift
+++ b/notification_schedule_ios/Views/EventListView.swift
@@ -5,6 +5,7 @@ import UIKit
 struct EventListView: View {
     @StateObject private var viewModel = EventListViewModel()
     @State private var showAdd = false
+    @State private var editingEvent: AppEvent?
 
     var body: some View {
         NavigationStack {
@@ -28,6 +29,11 @@ struct EventListView: View {
                         AddEventView()
                     }
                 )
+                .sheet(item: $editingEvent, onDismiss: {
+                    Task { await viewModel.loadEvents() }
+                }, content: { event in
+                    AddEventView(event: event)
+                })
                 .alert("エラー", isPresented: $viewModel.showError) {
                     Button("OK", role: .cancel) {}
                 } message: {
@@ -46,11 +52,16 @@ struct EventListView: View {
             } else {
                 List {
                     ForEach(viewModel.events) { event in
-                        VStack(alignment: .leading) {
-                            Text(event.title).font(.headline)
-                            Text(event.startDate, style: .date)
-                            Text(event.startDate, style: .time)
+                        Button {
+                            editingEvent = event
+                        } label: {
+                            VStack(alignment: .leading) {
+                                Text(event.title).font(.headline)
+                                Text(event.startDate, style: .date)
+                                Text(event.startDate, style: .time)
+                            }
                         }
+                        .buttonStyle(.plain)
                     }
                     .onDelete { indexSet in
                         viewModel.delete(at: indexSet)


### PR DESCRIPTION
## Summary
- allow selecting events from the list to open them in an edit sheet
- pre-populate the event form for editing and adjust the save action accordingly
- add service and model support for updating events and tracking alarm offsets

## Testing
- xcodebuild -list -project notification_schedule_ios.xcodeproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cac0d75204832e9b76a86e2a579392